### PR TITLE
move to icqq & Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Dockerfile for oicq2-http
+
+FROM node:19
+
+# 运行文件夹
+WORKDIR /usr/src/app
+# 拷贝文件
+# PS：因为 oicq2 预先构建需要依赖 src 文件夹
+# 所以干脆把整个文件夹拷贝进去，反正构建也不慢
+COPY . .
+# 安装依赖
+RUN yarn install
+
+# 参数
+ENV ID=1234567890
+ENV PORT=5700
+
+# 暴露端口
+EXPOSE $PORT
+
+# 运行
+CMD yarn start $ID

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
+    "icqq": "^0.0.31",
     "multiparty": "^4.2.3",
-    "oicq": "^2.3.1",
     "ws": "^8.8.1"
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -5,7 +5,7 @@ import multiparty from "multiparty";
 import WebSocket from "ws";
 import { WebSocketServer } from "ws";
 import crypto from "crypto";
-import * as oicq from "oicq";
+import * as oicq from "icqq";
 import * as api from "./api";
 import { Config, configDir } from "./configs";
 import { AddressInfo } from "net";
@@ -59,11 +59,11 @@ function startup(account: number, configs: { [k: string]: Config }) {
   }
   createBot(account, config, passFile);
   createServer(config);
-  setTimeout(botLogin, 500, passFile);
+  setTimeout(botLogin, 500, account, passFile);
 }
 
 function createBot(account: number, config: Config, passFile: string) {
-  bot = oicq.createClient(account, {
+  bot = oicq.createClient({
     log_level: config.log_level,
     platform: config.platform,
     ignore_self: config.ignore_self,
@@ -99,7 +99,7 @@ function createBot(account: number, config: Config, passFile: string) {
       bot.login();
     }
     if (data.message.includes("密码错误")) {
-      botLoginWithPassword(passFile);
+      botLoginWithPassword(account, passFile);
     } else {
       bot.terminate();
     }
@@ -319,16 +319,16 @@ async function onHttpReq(
   }
 }
 
-function botLogin(passFile: string) {
+function botLogin(account: number, passFile: string) {
   try {
     const password = fs.readFileSync(passFile);
-    bot.login(password.length ? password : undefined);
+    bot.login(account, password.length ? password : undefined);
   } catch {
-    botLoginWithPassword(passFile);
+    botLoginWithPassword(account, passFile);
   }
 }
 
-function botLoginWithPassword(passFile: string) {
+function botLoginWithPassword(account: number, passFile: string) {
   console.log("请输入密码 (直接按回车扫码登录): ");
   process.stdin.once("data", (input) => {
     let inputStr = input.toString().trim();
@@ -340,7 +340,7 @@ function botLoginWithPassword(passFile: string) {
     fs.writeFileSync(passFile, password, {
       mode: 0o600,
     });
-    return bot.login(password);
+    return bot.login(account, password);
   });
 }
 

--- a/src/extra.ts
+++ b/src/extra.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig } from "axios";
-import * as oicq from "oicq";
+import * as oicq from "icqq";
 import fs from "fs";
 
 export const extraActions = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import startup from "./core";
 import configs from "./configs";
-import { Client } from "oicq";
+import { Client } from "icqq";
 
 const account = parseInt(process.argv[process.argv.length - 1] as string);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,15 @@ axios@^0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
+axios@^1.1.2:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
+  integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -214,7 +223,7 @@ flatted@^3.2.7:
   resolved "https://registry.npmmirror.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.14.9:
+follow-redirects@^1.14.9, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -260,6 +269,19 @@ iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+icqq@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/icqq/-/icqq-0.0.31.tgz#c0b8461bf0d8d87509b52005b7abdaf25729f36c"
+  integrity sha512-Oy2zG1hWpWhKFHq1J8ZV8JFdNW8jks6V+qWE9ZVsvCDfH2EG1urX5nO4u9/GMGYej0hVBSUivRww+i024wiKRA==
+  dependencies:
+    axios "^1.1.2"
+    lodash "^4.17.21"
+    log4js "^6.3.0"
+    long "^4.0.0"
+    pngjs "^6.0.0"
+    probe-image-size "^7.2.2"
+    triptrap "^0.0.13-1"
+
 inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
@@ -276,6 +298,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmmirror.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log4js@^6.3.0:
   version "6.7.0"
@@ -338,17 +365,6 @@ needle@^2.5.2:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
-oicq@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmmirror.com/oicq/-/oicq-2.3.1.tgz#833cfb239c08e201d3ef203e347aee94bc2392c1"
-  integrity sha512-mRw/GgdRKFMylnrlnnywzCIwvad6fF5E4WZfIlval070wEc3w9yMV49i9epFltWkU/JGNMDS4t5wWdZEYzW0EQ==
-  dependencies:
-    axios "^0.27.2"
-    log4js "^6.3.0"
-    long "^4.0.0"
-    pngjs "^6.0.0"
-    probe-image-size "^7.2.2"
-
 pngjs@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmmirror.com/pngjs/-/pngjs-6.0.0.tgz#ca9e5d2aa48db0228a52c419c3308e87720da821"
@@ -362,6 +378,11 @@ probe-image-size@^7.2.2:
     lodash.merge "^4.6.2"
     needle "^2.5.2"
     stream-parser "~0.3.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 random-bytes@~1.0.0:
   version "1.0.0"
@@ -418,6 +439,11 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+triptrap@^0.0.13-1:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/triptrap/-/triptrap-0.0.13.tgz#6b15b8c28a920f8dc061ae6706bd69a60ebd14db"
+  integrity sha512-9loAYStccfzGQepJpvgurodXADkg/10uxw67KOIMnmzG1bFcBPbWLSVbwp8xR8Yb0tZuFVcL2siHlIWq1AwBfA==
 
 uid-safe@2.1.5:
   version "2.1.5"


### PR DESCRIPTION
:sparkles: 将依赖从 oicq 迁移到了 icqq（ https://github.com/icqqjs/icqq ），这是个 oicq 的分支 emmm 主要是用来解决 oicq 好久好久没更新了导致的登陆协议过旧无法 **正常** 登陆的问题（其实用其他 bot 生成的凭据也勉强能用）
:sparkles: 写了个 Dockerfile 虽然是自己用的（x