### PR TITLE
add get_class_info

### DIFF
--- a/src/extra.ts
+++ b/src/extra.ts
@@ -61,6 +61,10 @@ export const extraActions = {
     };
   },
 
+  get_class_info: async (bot: oicq.Client, data: any): Promise<Object> => {
+    return Array.from(bot.classes, ([key, value]) => ({[key]: value}));
+  },
+
   // PS：它有时候 pick 到的对象是空的但是操作也能成功，很迷惑所以我不进行空判断了
   set_message_read: async (bot: oicq.Client, data: any): Promise<Object> => {
     bot.reportReaded(data.params.message_id);


### PR DESCRIPTION
由于在 oicq 中好友信息和分组名是同时获取的（ [takayama-lily/oicq/.../internal.ts#L181](https://github.com/takayama-lily/oicq/blob/d6a67b2f49c1c33f295039ab2c0bc6b3d839f829/lib/internal/internal.ts#L181) ）导致好友信息里没有返回分组名，追加一个接口来单独获取一份分组名。-> https://github.com/Stapxs/Stapxs-QQ-Lite-2.0/issues/51